### PR TITLE
Revert "ci: optimize workflow (#13)"

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,7 +13,10 @@ name: "CodeQL"
 
 on:
   push:
+    branches: [ main ]
   pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ main ]
   schedule:
     - cron: '15 17 * * 5'
 
@@ -21,7 +24,6 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
-    if: ${{ github.event_name != 'pull_request' || github.repository_owner != github.event.pull_request.head.repo.owner.login }}
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -2,12 +2,13 @@ name: jest
 
 on:
   push:
+    branches: [main]
   pull_request:
+    branches: [main]
 
 jobs:
   jest:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name != 'pull_request' || github.repository_owner != github.event.pull_request.head.repo.owner.login }}
 
     strategy:
       matrix:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,12 +2,13 @@ name: lint
 
 on:
   push:
+    branches: [main]
   pull_request:
+    branches: [main]
 
 jobs:
   lint:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name != 'pull_request' || github.repository_owner != github.event.pull_request.head.repo.owner.login }}
 
     strategy:
       matrix:


### PR DESCRIPTION
## Changes:

- Reverts pull request renovatebot/node-schedule#13

## Context:

Seems the new workflow logic has a problem with CodeQL scans.
@viceice said in https://github.com/renovatebot/renovate/pull/10490

> Reverted the skipping as it will only run on main branch and pr's targeting main. Do we want to run it on renovate or other branches too?

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository